### PR TITLE
Auth rewrite

### DIFF
--- a/config_sample.yaml
+++ b/config_sample.yaml
@@ -33,7 +33,7 @@ livekit_info:
   api_key: "APIiYAA5w37Cfo2"
   secret: "6aNur7qqupeZhFYNOJVUyeXxXhVw8f4lm13pEDUx8SgB"
   # value in minutes. Default 10 minutes. Client will renew token automatically
-  token_validity: 2h
+  token_validity: 10m
 redis_info:
   host: redis
   port: "6379"

--- a/internal/controllers/auth_token.go
+++ b/internal/controllers/auth_token.go
@@ -74,6 +74,18 @@ func HandleGenerateJoinToken(c *fiber.Ctx) error {
 }
 
 func HandleVerifyToken(c *fiber.Ctx) error {
+	roomId := c.Locals("roomId")
+	requestedUserId := c.Locals("requestedUserId")
+
+	rs := models.NewRoomService()
+	exist := rs.IsUserExistInBlockList(roomId.(string), requestedUserId.(string))
+	if exist {
+		return c.JSON(fiber.Map{
+			"status": false,
+			"msg":    "notifications.you-are-blocked",
+		})
+	}
+
 	req := new(struct {
 		IsProduction *bool `json:"is_production,omitempty"`
 	})
@@ -103,7 +115,6 @@ func HandleVerifyToken(c *fiber.Ctx) error {
 	// if production then we'll check if room is active or not
 	// if not active then we don't allow to join user
 	// livekit also don't allow but throw 500 error which make confused to user.
-	roomId := c.Locals("roomId")
 	m := models.NewRoomAuthModel()
 	status, msg := m.IsRoomActive(&models.IsRoomActiveReq{
 		RoomId: roomId.(string),

--- a/internal/controllers/webhook.go
+++ b/internal/controllers/webhook.go
@@ -27,7 +27,9 @@ func HandleWebhook(c *fiber.Ctx) error {
 	}
 	m := models.NewAuthTokenModel()
 
-	claims, err := m.DoValidateToken(req)
+	// here request is coming from livekit
+	// so, we'll use livekit secret to validate
+	claims, err := m.DoValidateToken(req, true)
 	if err != nil {
 		return c.SendStatus(fiber.StatusForbidden)
 	}

--- a/internal/controllers/websocket_service.go
+++ b/internal/controllers/websocket_service.go
@@ -44,7 +44,7 @@ func (c *websocketController) validation() bool {
 		Token: c.token,
 	}
 
-	claims, err := m.DoValidateToken(info)
+	claims, err := m.DoValidateToken(info, false)
 	if err != nil {
 		err = c.kws.EmitTo(c.kws.UUID, []byte("invalid token"))
 		if err == nil {

--- a/internal/models/room_service.go
+++ b/internal/models/room_service.go
@@ -245,6 +245,6 @@ func (r *RoomService) IsUserExistInBlockList(roomId, userId string) bool {
 }
 
 func (r *RoomService) DeleteRoomBlockList(roomId string) (int64, error) {
-	key := BlockedUsersList + ":" + roomId
+	key := BlockedUsersList + roomId
 	return r.rc.Del(r.ctx, key).Result()
 }

--- a/internal/models/room_service.go
+++ b/internal/models/room_service.go
@@ -231,12 +231,12 @@ func (r *RoomService) SendData(roomId string, data []byte, dataPacket_Kind livek
 }
 
 func (r *RoomService) AddUserToBlockList(roomId, userId string) (int64, error) {
-	key := BlockedUsersList + ":" + roomId
+	key := BlockedUsersList + roomId
 	return r.rc.SAdd(r.ctx, key, userId).Result()
 }
 
 func (r *RoomService) IsUserExistInBlockList(roomId, userId string) bool {
-	key := BlockedUsersList + ":" + roomId
+	key := BlockedUsersList + roomId
 	exist, err := r.rc.SIsMember(r.ctx, key, userId).Result()
 	if err != nil {
 		return false

--- a/internal/models/room_service.go
+++ b/internal/models/room_service.go
@@ -13,6 +13,7 @@ import (
 const (
 	RoomsKey               = "rooms"
 	RoomParticipantsPrefix = "room_participants:"
+	BlockedUsersList       = "pnm:block_users_list:"
 )
 
 type RoomService struct {
@@ -227,4 +228,23 @@ func (r *RoomService) SendData(roomId string, data []byte, dataPacket_Kind livek
 	}
 
 	return res, nil
+}
+
+func (r *RoomService) AddUserToBlockList(roomId, userId string) (int64, error) {
+	key := BlockedUsersList + ":" + roomId
+	return r.rc.SAdd(r.ctx, key, userId).Result()
+}
+
+func (r *RoomService) IsUserExistInBlockList(roomId, userId string) bool {
+	key := BlockedUsersList + ":" + roomId
+	exist, err := r.rc.SIsMember(r.ctx, key, userId).Result()
+	if err != nil {
+		return false
+	}
+	return exist
+}
+
+func (r *RoomService) DeleteRoomBlockList(roomId string) (int64, error) {
+	key := BlockedUsersList + ":" + roomId
+	return r.rc.Del(r.ctx, key).Result()
 }

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -230,10 +230,11 @@ func (u *userModel) muteUnmuteAllMic(r *MuteUnMuteTrackReq) error {
 }
 
 type RemoveParticipantReq struct {
-	Sid    string `json:"sid" validate:"required"`
-	RoomId string `json:"room_id" validate:"required"`
-	UserId string `json:"user_id" validate:"required"`
-	Msg    string `json:"msg" validate:"required"`
+	Sid       string `json:"sid" validate:"required"`
+	RoomId    string `json:"room_id" validate:"required"`
+	UserId    string `json:"user_id" validate:"required"`
+	Msg       string `json:"msg" validate:"required"`
+	BlockUser bool   `json:"block_user"`
 }
 
 func (u *userModel) RemoveParticipant(r *RemoveParticipantReq) error {
@@ -258,6 +259,11 @@ func (u *userModel) RemoveParticipant(r *RemoveParticipantReq) error {
 	_, err = u.roomService.RemoveParticipant(r.RoomId, r.UserId)
 	if err != nil {
 		return err
+	}
+
+	// finally check if requested to block as well as
+	if r.BlockUser {
+		_, _ = u.roomService.AddUserToBlockList(r.RoomId, r.UserId)
 	}
 
 	return nil

--- a/internal/models/webhook.go
+++ b/internal/models/webhook.go
@@ -109,6 +109,9 @@ func (w *webhookEvent) roomFinished() int64 {
 	em := NewEtherpadModel()
 	_ = em.CleanAfterRoomEnd(event.Room.Name, event.Room.Metadata)
 
+	// clear users block list
+	_, _ = w.roomService.DeleteRoomBlockList(event.Room.Name)
+
 	return affected
 }
 


### PR DESCRIPTION
Now plugnmeet will use it's own token. When all the validation will be pass that time it will generate seperate token for livekit & send it back to client. Later client can use it to connect with livekit. plugnmeet will take care for it's own token renew task. Livekit also do it's own. This way user no longer able to use same token to login in livekit using any other client. 