### PR TITLE
refact: make seperation of websocket channel

### DIFF
--- a/internal/models/breakout_room.go
+++ b/internal/models/breakout_room.go
@@ -384,19 +384,14 @@ func (m *breakoutRoom) broadcastNotification(roomId, fromUserId, toUserId, broad
 		payload.To = toUserId
 	}
 
-	msg := WebsocketRedisMsg{
+	msg := &WebsocketRedisMsg{
 		Type:    "sendMsg",
 		Payload: &payload,
 		RoomId:  roomId,
 		IsAdmin: isAdmin,
 	}
+	DistributeWebsocketMsgToRedisChannel(msg)
 
-	marshal, err := json.Marshal(msg)
-	if err != nil {
-		return err
-	}
-
-	m.rc.Publish(m.ctx, "plug-n-meet-websocket", marshal)
 	return nil
 }
 

--- a/internal/models/polls.go
+++ b/internal/models/polls.go
@@ -269,19 +269,14 @@ func (m *newPollsModel) broadcastNotification(roomId, userId, pollId, mType stri
 		},
 	}
 
-	msg := WebsocketRedisMsg{
+	msg := &WebsocketRedisMsg{
 		Type:    "sendMsg",
 		Payload: &payload,
 		RoomId:  roomId,
 		IsAdmin: isAdmin,
 	}
+	DistributeWebsocketMsgToRedisChannel(msg)
 
-	marshal, err := json.Marshal(msg)
-	if err != nil {
-		return err
-	}
-
-	m.rc.Publish(m.ctx, "plug-n-meet-websocket", marshal)
 	return nil
 }
 

--- a/internal/models/webhook.go
+++ b/internal/models/webhook.go
@@ -128,7 +128,7 @@ func (w *webhookEvent) roomFinished() int64 {
 	}
 	marshal, err := json.Marshal(msg)
 	if err == nil {
-		config.AppCnf.RDS.Publish(context.Background(), "plug-n-meet-websocket", marshal)
+		config.AppCnf.RDS.Publish(context.Background(), "plug-n-meet-user-websocket", marshal)
 	}
 
 	// notify to clean room from room duration map

--- a/internal/models/websocket_channels.go
+++ b/internal/models/websocket_channels.go
@@ -1,0 +1,103 @@
+package models
+
+import (
+	"context"
+	"github.com/goccy/go-json"
+	"github.com/mynaparrot/plugNmeet/internal/config"
+	log "github.com/sirupsen/logrus"
+)
+
+func DistributeWebsocketMsgToRedisChannel(msg *WebsocketRedisMsg) {
+	ctx := context.Background()
+	marshal, err := json.Marshal(msg)
+	if err != nil {
+		log.Errorln(err)
+		return
+	}
+
+	switch msg.Payload.Type {
+	case "USER":
+		config.AppCnf.RDS.Publish(ctx, "plug-n-meet-user-websocket", marshal)
+	case "WHITEBOARD":
+		config.AppCnf.RDS.Publish(ctx, "plug-n-meet-whiteboard-websocket", marshal)
+	case "SYSTEM":
+		config.AppCnf.RDS.Publish(ctx, "plug-n-meet-system-websocket", marshal)
+	}
+}
+
+// SubscribeToUserWebsocketChannel will delivery message to user websocket
+func SubscribeToUserWebsocketChannel() {
+	ctx := context.Background()
+	pubsub := config.AppCnf.RDS.Subscribe(ctx, "plug-n-meet-user-websocket")
+	defer pubsub.Close()
+
+	_, err := pubsub.Receive(ctx)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	m := NewWebsocketService()
+	ch := pubsub.Channel()
+	for msg := range ch {
+		res := new(WebsocketRedisMsg)
+		err = json.Unmarshal([]byte(msg.Payload), res)
+		if err != nil {
+			log.Errorln(err)
+		}
+		if res.Type == "sendMsg" {
+			m.HandleDataMessages(res.Payload, res.RoomId, res.IsAdmin)
+		} else if res.Type == "deleteRoom" {
+			config.AppCnf.DeleteChatRoom(res.RoomId)
+		}
+	}
+}
+
+// SubscribeToWhiteboardWebsocketChannel will delivery message to whiteboard websocket
+func SubscribeToWhiteboardWebsocketChannel() {
+	ctx := context.Background()
+	pubsub := config.AppCnf.RDS.Subscribe(ctx, "plug-n-meet-whiteboard-websocket")
+	defer pubsub.Close()
+
+	_, err := pubsub.Receive(ctx)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	m := NewWebsocketService()
+	ch := pubsub.Channel()
+	for msg := range ch {
+		res := new(WebsocketRedisMsg)
+		err = json.Unmarshal([]byte(msg.Payload), res)
+		if err != nil {
+			log.Errorln(err)
+		}
+		if res.Type == "sendMsg" {
+			m.HandleDataMessages(res.Payload, res.RoomId, res.IsAdmin)
+		}
+	}
+}
+
+// SubscribeToSystemWebsocketChannel will delivery message to websocket
+func SubscribeToSystemWebsocketChannel() {
+	ctx := context.Background()
+	pubsub := config.AppCnf.RDS.Subscribe(ctx, "plug-n-meet-system-websocket")
+	defer pubsub.Close()
+
+	_, err := pubsub.Receive(ctx)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	m := NewWebsocketService()
+	ch := pubsub.Channel()
+	for msg := range ch {
+		res := new(WebsocketRedisMsg)
+		err = json.Unmarshal([]byte(msg.Payload), res)
+		if err != nil {
+			log.Errorln(err)
+		}
+		if res.Type == "sendMsg" {
+			m.HandleDataMessages(res.Payload, res.RoomId, res.IsAdmin)
+		}
+	}
+}

--- a/internal/models/websocket_channels.go
+++ b/internal/models/websocket_channels.go
@@ -71,9 +71,7 @@ func SubscribeToWhiteboardWebsocketChannel() {
 		if err != nil {
 			log.Errorln(err)
 		}
-		if res.Type == "sendMsg" {
-			m.HandleDataMessages(res.Payload, res.RoomId, res.IsAdmin)
-		}
+		m.HandleDataMessages(res.Payload, res.RoomId, res.IsAdmin)
 	}
 }
 
@@ -96,8 +94,6 @@ func SubscribeToSystemWebsocketChannel() {
 		if err != nil {
 			log.Errorln(err)
 		}
-		if res.Type == "sendMsg" {
-			m.HandleDataMessages(res.Payload, res.RoomId, res.IsAdmin)
-		}
+		m.HandleDataMessages(res.Payload, res.RoomId, res.IsAdmin)
 	}
 }


### PR DESCRIPTION
If we use single channel & if there is any delay to deliver messages then all the other messages will be in queue. This will lead unnecessay delays. In this PR I've seperated into 3 channels. 
```
plug-n-meet-user-websocket
plug-n-meet-whiteboard-websocket
plug-n-meet-system-websocket
```