### PR TITLE
fixed: lti sign validation wasn't successful behind proxy

### DIFF
--- a/cmd/server/version.go
+++ b/cmd/server/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version = "1.1.7"
+const Version = "1.1.8"

--- a/config_sample.yaml
+++ b/config_sample.yaml
@@ -85,3 +85,5 @@ shared_notepad:
       id: "node_01"
       host: "http://host.docker.internal:9001"
       api_key: "eb2fb3fb78ca29eb6896852517d34a1be5f320664e3cce3a522a06dfa278f169"
+lti_info:
+  v1_tool_url: http://localhost:8080/lti/v1

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,7 @@ type AppConfig struct {
 	UploadFileSettings UploadFileSettings `yaml:"upload_file_settings"`
 	RecorderInfo       RecorderInfo       `yaml:"recorder_info"`
 	SharedNotePad      SharedNotePad      `yaml:"shared_notepad"`
+	LtiInfo            LtiInfo            `yaml:"lti_info"`
 }
 
 type ClientInfo struct {
@@ -112,6 +113,10 @@ type EtherpadInfo struct {
 	Id     string `yaml:"id"`
 	Host   string `yaml:"host"`
 	ApiKey string `yaml:"api_key"`
+}
+
+type LtiInfo struct {
+	V1ToolUrl string `yaml:"v1_tool_url"`
 }
 
 type ChatParticipant struct {

--- a/pkg/controllers/lti_v1.go
+++ b/pkg/controllers/lti_v1.go
@@ -1,9 +1,9 @@
 package controllers
 
 import (
-	"fmt"
 	"github.com/goccy/go-json"
 	"github.com/gofiber/fiber/v2"
+	"github.com/mynaparrot/plugNmeet/pkg/config"
 	"github.com/mynaparrot/plugNmeet/pkg/models"
 )
 
@@ -15,9 +15,8 @@ func HandleLTIV1Landing(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusUnauthorized).SendString("empty body")
 	}
 
-	signingURL := fmt.Sprintf("%v://%v%v", c.Protocol(), c.Hostname(), c.OriginalURL())
 	m := models.NewLTIV1Model()
-	err := m.LTIV1Landing(c, string(b), signingURL)
+	err := m.LTIV1Landing(c, string(b), config.AppCnf.LtiInfo.V1ToolUrl)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When plugNmeet is behind the proxy that time it give incorrect output for `c.Protocol()` as proxy send data to non-ssl. This create problem during validation. Now we'll require to set correct tool URL in configuration file. This way validation will be correct.